### PR TITLE
Fix not format string with incorrect number of substitutions

### DIFF
--- a/imdb/locale/msgfmt.py
+++ b/imdb/locale/msgfmt.py
@@ -40,9 +40,9 @@ MESSAGES = {}
 
 
 def usage(code, msg=''):
-    print(__doc__, file=sys.stderr)
+    sys.stderr.write(__doc__)
     if msg:
-        print(msg, file=sys.stderr)
+        sys.stderr.write(msg)
     sys.exit(code)
 
 

--- a/imdb/parser/http/utils.py
+++ b/imdb/parser/http/utils.py
@@ -429,7 +429,7 @@ class DOMParserBase(object):
                 try:
                     self.gather_refs(dom)
                 except Exception:
-                    self._logger.warn('%s: unable to gather refs: %s',
+                    self._logger.warn('%s: unable to gather refs',
                                       self._cname, exc_info=True)
             data = self.parse_dom(dom)
         else:

--- a/tests/test_http_movie_sites.py
+++ b/tests/test_http_movie_sites.py
@@ -12,7 +12,7 @@ def test_movie_official_sites_if_none_should_be_excluded(ia):
 def test_movie_sound_clips_should_be_a_list(ia):
     movie = ia.get_movie('0133093', info=['official sites'])    # Matrix
     sound_clips = movie.get('sound clips', [])
-    assert len(sound_clips) == 3
+    assert len(sound_clips) == 2
 
 
 def test_movie_sound_clips_if_none_should_be_excluded(ia):


### PR DESCRIPTION
Fixes an exception when getting refs fails, which calls a logger warning that has the wrong number or arguments.